### PR TITLE
docs(README): '--patch-version-pattern' example respecting commit scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ highestTag=$(npx git-changelog-command-line \
  --print-highest-version-tag)
 
 nextVersion=$(npx git-changelog-command-line \
- --patch-version-pattern "fix:.*" \
+ --patch-version-pattern "^fix.*" \
  --print-next-version)
 
 if [ "$nextVersion" == "$highestTag" ]; then


### PR DESCRIPTION
Given example for '--patch-version-pattern' usage would omit those 'fix' commits, which contain a conventionalcommt-scope